### PR TITLE
update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,52 +5,72 @@
 #contributor: Paul Helter (provided base environment_setup to base this off of)
 #SEE: ~/cmake/environment_setup.sh for source
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 #Following Docker recommended convention for custom image based on maintained image
 #GCC and required items, multi-lib for 32-bit support, coverage tool
 RUN apt-get update -y \
-	&& apt-get install -y \
-	clang-format-6.0 \
-	clang-tidy-6.0 \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=10 --no-install-recommends \
+	clang-format \
+	clang-tidy \
 	cmake \
 	default-jdk \
 	doxygen \
+	g++ \
 	git \
 	graphviz \
 	iwyu \
 	lcov \
-	ninja-build \
-	software-properties-common \
-	srecord \
-	wget \ 
-	zip
-
-#Have to split out these installs because they must be installed after dependencies in the previous RUN
-#This may no longer be true after removing gcc-arm-none-eabi from apt-get install list and running autoremove
-RUN apt-get install -y \
-	binutils-arm-linux-gnueabi \
-	gcc-arm-linux-gnueabi \
-	libc6-armel-cross \
-	libc6-dev-armel-cross \
-	libncurses5-dev
-
-#Install Protobuf and compilers
-RUN apt-get install -y \
+	libncurses5-dev \
 	libprotobuf-dev \
+	man \
+	ninja-build \
 	protobuf-compiler \
-	python-protobuf
+	python-is-python2 \
+	python-protobuf \
+	srecord \
+	unzip \
+	vim \
+	wget \
+	zip && \
+	apt-get autoclean -y && apt-get --purge --yes autoremove && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-#Crosscompiler Install with cleaning
-RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa \
-	&& apt-get update -y \
-	&& apt-get autoremove -y \
-	&& apt-get install -y \
-	gcc-arm-embedded \
-	gcc-multilib \ 
-	gcc-7 \
-	g++-multilib \
-	g++-7
+# Install cross-compiler
+ENV ARM_VERSION=10.3-2021.10
+RUN cd /tmp && \
+	wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/${ARM_VERSION}/gcc-arm-none-eabi-${ARM_VERSION}-x86_64-linux.tar.bz2 && \
+	tar -xf gcc-arm-none-eabi-${ARM_VERSION}-x86_64-linux.tar.bz2 --strip-components=1 -C /usr && \
+	rm -rf /tmp/*
 
-#Clean up apt lists to reduce image size.
-RUN rm -r /var/lib/apt/lists/*
+# Install Simplicity Commander (to build upgrade images)
+RUN cd /tmp && \
+	wget https://www.silabs.com/documents/public/software/SimplicityCommander-Linux.zip && \
+	unzip SimplicityCommander-Linux.zip && \
+	tar -xf SimplicityCommander-Linux/Commander_linux_x86_64_*.tar.bz -C /usr/local/ && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENV PATH=/usr/local/commander/:$PATH
+
+
+RUN mkdir /root/java && \
+	cd /root/java && \
+	wget -O plantuml.jar http://sourceforge.net/projects/plantuml/files/plantuml.jar/download
+
+ENV PLANTUML_DIR=/root/java
+
+# Upgrade Doxygen to fix some warnings
+ENV DOXYGEN_VERSION=1.9.2
+RUN apt-get update -y \
+	&& apt-get remove doxygen -y \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=10 --no-install-recommends \
+	make \
+	libclang1-9 \
+	libclang-cpp9 \
+	&& \
+	cd /tmp && \
+	wget https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz && \
+	tar -xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz && \
+	cd doxygen-${DOXYGEN_VERSION} && \
+	make install && \
+	apt-get autoclean -y && apt-get --purge --yes autoremove && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Supporting image update for: https://github.com/Plantiga/firmware/pull/445

Use an updated Docker image with:

* Ubuntu 20.04
* GCC 10.3
* clang{-tidy,format} 10
* Simplicity Commander
* PlantUML
* Doxygen 1.9.2