### PR TITLE
fix: add openssh-client to allow proper git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,9 @@ RUN apt-get update -y \
 	make install && \
 	apt-get autoclean -y && apt-get --purge --yes autoremove && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN apt-get update -y \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=10 --no-install-recommends \
+	openssh-client && \
+	apt-get autoclean -y && apt-get --purge --yes autoremove && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
CircleCI's git client has trouble with `.gitignore`d files that are force added, but it won't clone without git & ssh available.

https://app.circleci.com/pipelines/github/Plantiga/firmware/1925/workflows/fddf906c-a7e6-4a4a-a077-bebe4b71e1ba/jobs/12683
